### PR TITLE
88 redirect to profile

### DIFF
--- a/app/components/modals/modalLogin.tsx
+++ b/app/components/modals/modalLogin.tsx
@@ -2,7 +2,7 @@
 import React, {useState} from "react";
 
 import { fetcher } from '@/lib/api';
-import { setAuthData } from '@/lib/auth';
+import { setAuthData, getAuthData } from '@/lib/auth';
 import { isValidEmail } from '@/lib/utils/validationUtils';
 import ErrorMess from "../errorMess";
 
@@ -60,7 +60,8 @@ const ModalLogin = ({
                     return;
                 }
                 setAuthData(response);
-                window.location.href = '/';
+                const page = await defineRole()
+                window.location.href = `/${page}`;
             } 
             catch (error) {
                 setError('Неверная почта или пароль');
@@ -68,6 +69,25 @@ const ModalLogin = ({
             }
         }
     };
+
+
+    const defineRole = async () => {
+        const { id } = getAuthData()
+        const fetchData = async () => {     
+            const response = await fetcher(`${process.env.NEXT_PUBLIC_STRAPI_URL}/users/${id}?populate=*`);
+            return response.role.name
+        }
+        const userRole = await fetchData()
+        switch (userRole) {
+            case "Moderator": {
+                return "moderation"
+            }
+            case "Statistic": {
+                return "statistic"
+            }
+        }
+        return `myprofile/${id}`
+    }
     
     
     const handleChange = (e: any) => {

--- a/app/components/modals/modalLogin.tsx
+++ b/app/components/modals/modalLogin.tsx
@@ -5,7 +5,7 @@ import { fetcher } from '@/lib/api';
 import { setAuthData, getAuthData } from '@/lib/auth';
 import { isValidEmail } from '@/lib/utils/validationUtils';
 import ErrorMess from "../errorMess";
-
+import Loading from '@/app/loading'
 
 
 interface ModalProps {
@@ -31,6 +31,7 @@ const ModalLogin = ({
             "password": ""
         }
     )
+    const [loading, setLoading] = useState<boolean>(false);
 
     const handleSubmit = async (e: any) => {
         e.preventDefault();
@@ -59,6 +60,7 @@ const ModalLogin = ({
                     setError('Неверная почта или пароль');
                     return;
                 }
+                setLoading(true)
                 setAuthData(response);
                 const page = await defineRole()
                 window.location.href = `/${page}`;
@@ -66,6 +68,7 @@ const ModalLogin = ({
             catch (error) {
                 setError('Неверная почта или пароль');
                 console.error('Error:', error);
+                setLoading(false)
             }
         }
     };
@@ -97,6 +100,7 @@ const ModalLogin = ({
 
     return (
         <dialog className="modal bg-black/70" open={openModalLogin}>
+            {loading ? ( <Loading />) : (
             <div className="modal-box py-10 max-sm:w-full rounded-none flex items-center justify-center m-10">
                 <div className="modal-action absolute -top-3 right-6">
                     <form method="dialog">
@@ -149,6 +153,7 @@ const ModalLogin = ({
                     </div>
                 </form>
             </div>
+            )}
         </dialog>
     );
 };

--- a/app/components/modals/modalRegister.tsx
+++ b/app/components/modals/modalRegister.tsx
@@ -5,6 +5,7 @@ import { setAuthData, getAuthData } from '@/lib/auth';
 import { isValidEmail } from '@/lib/utils/validationUtils';
 
 import ErrorMess from "../errorMess";
+import Loading from '@/app/loading'
 
 
 interface ModalProps {
@@ -27,6 +28,7 @@ const ModalRegister = ({
         }
     )
     const [error, setError] = useState<string | undefined>(undefined);
+    const [loading, setLoading] = useState<boolean>(false);
 
 
     const handleChange = (e: any) => {
@@ -77,18 +79,21 @@ const ModalRegister = ({
                     console.error('Error:', response.error);
                     return;
                 }
+                setLoading(true)
                 setAuthData(response);
                 const { id } = getAuthData()
                 window.location.href = `/myprofile/${id}`;
             }
             catch (error) {
                 console.error('Error:', error);
+                setLoading(false)
             }
         }
     };
     
     return (
         <dialog className="modal bg-black/70" open={openModalRegister}>
+            {loading ? ( <Loading />) : (
             <div className="modal-box py-12 max-sm:w-full rounded-none flex items-center justify-center m-10">
                 <div className="modal-action absolute -top-2 right-6">
                     <form method="dialog">
@@ -138,6 +143,7 @@ const ModalRegister = ({
                     </div>
                 </form>
             </div>
+            )}
         </dialog>
     );
 };

--- a/app/components/modals/modalRegister.tsx
+++ b/app/components/modals/modalRegister.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useState } from "react";
 import { fetcher } from '@/lib/api';
-import { setAuthData } from '@/lib/auth';
+import { setAuthData, getAuthData } from '@/lib/auth';
 import { isValidEmail } from '@/lib/utils/validationUtils';
 
 import ErrorMess from "../errorMess";
@@ -78,7 +78,8 @@ const ModalRegister = ({
                     return;
                 }
                 setAuthData(response);
-                window.location.href = '/';
+                const { id } = getAuthData()
+                window.location.href = `/myprofile/${id}`;
             }
             catch (error) {
                 console.error('Error:', error);


### PR DESCRIPTION
# Переадресация на страницу профиля после входа/регистрации

- Добавлена функция для получения роли аккаунта, чтобы направлять на страницу студента или модератора в зависимости от роли

```JavaScript 
const defineRole = async () => {
        const { id } = getAuthData()
        const fetchData = async () => {     
            const response = await fetcher(`${process.env.NEXT_PUBLIC_STRAPI_URL}/users/${id}?populate=*`);
            return response.role.name
        }
        const userRole = await fetchData()
        switch (userRole) {
            case "Moderator": {
                return "moderation"
            }
            case "Statistic": {
                return "statistic"
            }
        }
        return `myprofile/${id}`
    }
```

- Добавлена анимация загрузки, аналогично как на страницах редактирования профиля/поста